### PR TITLE
html-gwt build.gradle file update

### DIFF
--- a/src/main/kotlin/com/github/czyzby/setup/data/platforms/gwt.kt
+++ b/src/main/kotlin/com/github/czyzby/setup/data/platforms/gwt.kt
@@ -217,6 +217,7 @@ task dist(dependsOn: [clean, compileGwt]) {
 task addSource {
 	doLast {
 		sourceSets.main.compileClasspath += files(project(':core').sourceSets.main.allJava.srcDirs)
+		sourceSets.main.compileClasspath += files(project(':shared').sourceSets.main.allJava.srcDirs)
 	}
 }
 

--- a/src/main/kotlin/com/github/czyzby/setup/data/platforms/gwt.kt
+++ b/src/main/kotlin/com/github/czyzby/setup/data/platforms/gwt.kt
@@ -217,7 +217,7 @@ task dist(dependsOn: [clean, compileGwt]) {
 task addSource {
 	doLast {
 		sourceSets.main.compileClasspath += files(project(':core').sourceSets.main.allJava.srcDirs)
-		sourceSets.main.compileClasspath += files(project(':shared').sourceSets.main.allJava.srcDirs)
+		${if(project.hasPlatform(Shared.ID)) "sourceSets.main.compileClasspath += files(project(':shared').sourceSets.main.allJava.srcDirs)" else ""}
 	}
 }
 


### PR DESCRIPTION
Closes #14 
+ `sourceSets.main.compileClasspath += files(project(':shared').sourceSets.main.allJava.srcDirs)`
- Application rebuilt, generated new project and ran correctly.