### PR TITLE
Fixed archiveVersion requiring .get() to get the version number.

### DIFF
--- a/src/main/kotlin/com/github/czyzby/setup/data/platforms/desktop.kt
+++ b/src/main/kotlin/com/github/czyzby/setup/data/platforms/desktop.kt
@@ -56,7 +56,7 @@ dependencies {
 ${joinDependencies(dependencies)}}
 
 jar {
-	archiveFileName = "${'$'}{appName}-${'$'}{archiveVersion}.jar"
+	archiveFileName = "${'$'}{appName}-${'$'}{archiveVersion.get()}.jar"
 	from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } } 
 	manifest {
 		attributes 'Main-Class': project.mainClassName

--- a/src/main/kotlin/com/github/czyzby/setup/data/platforms/jglfw.kt
+++ b/src/main/kotlin/com/github/czyzby/setup/data/platforms/jglfw.kt
@@ -48,7 +48,7 @@ dependencies {
 ${joinDependencies(dependencies)}}
 
 jar {
-	archiveFileName = "${'$'}{appName}-${'$'}{archiveVersion}.jar"
+	archiveFileName = "${'$'}{appName}-${'$'}{archiveVersion.get()}.jar"
 	from files(sourceSets.main.output.classesDirs)
 	from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } } 
 	manifest {

--- a/src/main/kotlin/com/github/czyzby/setup/data/platforms/lwjgl3.kt
+++ b/src/main/kotlin/com/github/czyzby/setup/data/platforms/lwjgl3.kt
@@ -67,7 +67,7 @@ run {
 	}
 }
 jar {
-	archiveFileName = "${'$'}{appName}-${'$'}{archiveVersion}.jar"
+	archiveFileName = "${'$'}{appName}-${'$'}{archiveVersion.get()}.jar"
 	from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } } 
 	manifest {
 		attributes 'Main-Class': project.mainClassName


### PR DESCRIPTION
Since [archiveVersion is a `Property<String>`](https://docs.gradle.org/current/dsl/org.gradle.jvm.tasks.Jar.html#org.gradle.jvm.tasks.Jar:archiveVersion) and not a `String` it requires a `.get()` call to get the actual version number. Else it'll use the `.toString()` function which results in unexpected filenames.

For example: `'lwjgl3\build\libs\GdxJpackage-task ':lwjgl3:jar' property 'archiveVersion'.jar'.`


