### PR TITLE
Reduce background GPU usage

### DIFF
--- a/src/main/kotlin/com/github/czyzby/setup/main.kt
+++ b/src/main/kotlin/com/github/czyzby/setup/main.kt
@@ -111,7 +111,7 @@ fun main() {
                 println("Application was not launched on first thread. " +
                         "Add VM argument -XstartOnFirstThread to avoid this.")
             }
-        }         
+        }
         throw error
     }
 }


### PR DESCRIPTION
This stops gdx-liftoff from rendering at a constant frame rate when its window isn't focused. This should reduce its GPU and CPU load when sitting in the background to practically zero.

Some things will still cause it to render while unfocused, such as UI changes (excluding _during_ animations) and wiggling the mouse around over the window.

P.S. When used without the `gdx-` part, is it `Liftoff` or `liftoff`? The README - which I very definitely read in its entirety and certainly didn't Ctrl+F through - uses both versions.