### PR TITLE
Centering the logo once more

### DIFF
--- a/src/main/resources/templates/header.lml
+++ b/src/main/resources/templates/header.lml
@@ -3,7 +3,7 @@
     <table background="window-bg" onCreate="initTitleTable" growX="true" height="26" padBottom="-20" row="true"
            colspan="3" touchable="enabled"/>
     -->
-    <image style="gdx-liftoff" fill="false" onClick="showSite" expandX="true" padLeft="60" padTop="26"/>
+    <image style="gdx-liftoff" fill="false" onClick="showSite" expandX="true" padTop="26"/>
     <!--
     <imageButton style="close-blue" image="icon-minus" toTitleTable="true" fill="false"
                  align="topRight" padTop="-6"/>


### PR DESCRIPTION
The removal of `header.lml`'s minimise/close buttons in 56ba529 resulted in the title going all wonky. Should you wish for this to be fixed, that's what this pull request does. At least, until the buttons get added back again next year.

Haven't updated the README because I don't have a `C:` drive.