### PR TITLE
Set sourceCompatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 
 version = "1.10.0.7-SNAPSHOT"
 mainClassName = 'com.github.czyzby.setup.MainKt'
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 jar {
   manifest {


### PR DESCRIPTION
From what I can see, `sourceCompatibility` gets set for the generated project, but isn't defined for gdx-liftoff itself. So if I build with JDK 11, it can't run on JRE 8, which is a little annoying.

If this is merged, I won't have to add it myself (or switch JDKs) to build for 8. And if it's rejected with reason, I can at least learn something.