### PR TITLE
README formatting adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A setup tool for [libGDX](https://libgdx.com/) Gradle projects.
 
 ![Screenshot of gdx-liftoff](.github/screenshot.png)
 
-<p align="center">
+<h1 align="center">
     :inbox_tray:
     <strong><a href="https://github.com/tommyettinger/gdx-liftoff/releases">DOWNLOAD</a></strong>
     :inbox_tray:
-</p>
+</h1>
 
 To generate a project, [download](https://github.com/tommyettinger/gdx-liftoff/releases) the latest application
 `jar` and execute it, or run the following command manually:


### PR DESCRIPTION
Minor formatting adjustment of the download section. Turns out font sizes render correctly in IntelliJ preview, but are ignored by GitHub. It's not quite what I was going for, but at least it stands out a bit more. It would probably make sense to go for an image to make it even easier for newcomers to navigate to the releases (or just straight up link to the latest `jar` on click).