### PR TITLE
Fixing the KTX modules URL in Third-party tab

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/libraries/unofficial/ktx.kt
+++ b/src/main/kotlin/gdx/liftoff/data/libraries/unofficial/ktx.kt
@@ -31,7 +31,7 @@ abstract class KtxExtension : Library {
     override val name
         get() = id.camelCaseToKebabCase()
     override val url: String
-        get() = "https://github.com/libktx/ktx/tree/master/" + id.removeSuffix("ktx").camelCaseToKebabCase()
+        get() = "https://github.com/libktx/ktx/tree/master/" + id.removePrefix("ktx").camelCaseToKebabCase()
 
     override fun initiate(project: Project) {
         project.properties["ktxVersion"] = KtxRepository.version


### PR DESCRIPTION
Currently the URL for KTX modules are prefixed with `ktx-`:
Ex: https://github.com/libktx/ktx/tree/master/ktx-app

This update removes the `ktx-` prefix which fixes KTX modules URL:
Ex: https://github.com/libktx/ktx/tree/master/app