### PR TITLE
Fix paths for Android platform

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
@@ -67,7 +67,7 @@ class Android : Platform {
         	tools:ignore="UnusedAttribute"
 			android:theme="@style/GdxTheme">
 		<activity
-				android:name="${project.basic.rootPackage}.AndroidLauncher"
+				android:name="${project.basic.rootPackage}.android.AndroidLauncher"
 				android:label="@string/app_name"
 				android:screenOrientation="landscape"
 				android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenSize|screenLayout"
@@ -231,7 +231,7 @@ task run(type: Exec) {
 	}
 
 	def adb = path + "/platform-tools/adb"
-	commandLine "${'$'}adb", 'shell', 'am', 'start', '-n', '${project.basic.rootPackage}/${project.basic.rootPackage}.AndroidLauncher'
+	commandLine "${'$'}adb", 'shell', 'am', 'start', '-n', '${project.basic.rootPackage}/${project.basic.rootPackage}.android.AndroidLauncher'
 }
 
 eclipse.project.name = appName + "-android"

--- a/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
@@ -197,12 +197,12 @@ public class GwtLauncher extends GwtApplication {""" + (
             project = project,
             platform = Android.ID,
             packageName = project.basic.rootPackage,
-            fileName = "AndroidLauncher.$launcherExtension",
+            fileName = "android/AndroidLauncher.$launcherExtension",
             content = getAndroidLauncherContent(project)
         )
     }
 
-    fun getAndroidLauncherContent(project: Project): String = """package ${project.basic.rootPackage}
+    fun getAndroidLauncherContent(project: Project): String = """package ${project.basic.rootPackage}.android;
 
 import android.os.Bundle;
 


### PR DESCRIPTION
I found two bugs when generating projects for the Android platform.

1) It is not compiling the source code when generating a **JAVA** project for the Android platform.
To reproduce this bug use these settings:
**Platforms**: Desktop, Android

2) Does not run the sample application in the Android emulator when generating a **KTX** project:
To reproduce this bug use these settings:
**Platforms**: Desktop, Android
**Languages**: Kotlin
**Third-party**: KTX App
**Tamplates**: Kotlin + KTX

This PR eliminates these bugs by fixing paths for the Android platform.

**Note**: Tested on Linux OS only.