### PR TITLE
Fix code style violations

### DIFF
--- a/src/main/kotlin/gdx/liftoff/views/MainView.kt
+++ b/src/main/kotlin/gdx/liftoff/views/MainView.kt
@@ -1,5 +1,3 @@
-
-
 package gdx.liftoff.views
 
 import com.badlogic.gdx.Gdx
@@ -37,7 +35,6 @@ import gdx.liftoff.config.inject
 import gdx.liftoff.config.threadPool
 import gdx.liftoff.data.platforms.Android
 import gdx.liftoff.data.project.Project
-import gdx.liftoff.data.templates.official.ClassicTemplate
 import gdx.liftoff.preferences.SdkVersionPreference
 import org.lwjgl.BufferUtils
 import org.lwjgl.glfw.GLFW
@@ -229,7 +226,7 @@ class MainView : ActionContainer {
     @LmlAction("jvmLanguages") fun getLanguages(): Array<String> = languagesData.languages
     @LmlAction("jvmLanguagesVersions") fun getLanguagesVersions(): Array<String> = languagesData.versions
     @LmlAction("templates") fun getOfficialTemplates(): Array<String> =
-        templatesData.officialTemplates.map { it.id }.sortedWith { left, right -> if(left == "classic") -1 else if (right == "classic") 1 else left.compareTo(right) }
+        templatesData.officialTemplates.map { it.id }.sortedWith { left, right -> if (left == "classic") -1 else if (right == "classic") 1 else left.compareTo(right) }
             .toTypedArray()
 
     @LmlAction("thirdPartyTemplates") fun getThirdPartyTemplates(): Array<String> =
@@ -309,7 +306,7 @@ class MainView : ActionContainer {
 
             override fun exit(event: InputEvent?, x: Float, y: Float, pointer: Int, toActor: Actor?) {
                 super.exit(event, x, y, pointer, toActor)
-                if(actor.stage?.scrollFocus == actor)
+                if (actor.stage?.scrollFocus == actor)
                     actor.stage?.scrollFocus = null
             }
         })


### PR DESCRIPTION
I was recently trying to build the latest and greatest snapshot, but I thought it didn't work, but it actually did work - the red text was just spooky enough to make me think it didn't work.

```
KtLint found code style violations. Please see the following reports:
```

```
[90m/home/james/github/gdx-liftoff/src/main/kotlin/gdx/liftoff/views/[0mMainView.kt[90m:[0m40[90m:1:[0m Unused import
[90m/home/james/github/gdx-liftoff/src/main/kotlin/gdx/liftoff/views/[0mMainView.kt[90m:[0m232[90m:85:[0m Missing spacing after "if"
[90m/home/james/github/gdx-liftoff/src/main/kotlin/gdx/liftoff/views/[0mMainView.kt[90m:[0m312[90m:19:[0m Missing spacing after "if"
```

(yes, the characters are broken on my end - that's not just GitHub)

So I've fixed the violations in hopes the red text will never return. It's possible something is different on my end than yours - the IDE was saying something about Kotlin versions.