### PR TITLE
Fix links and stuff

### DIFF
--- a/GWT.md
+++ b/GWT.md
@@ -1,10 +1,6 @@
-Guide to HTML Deployment with GWT
-#####
+# Guide to HTML Deployment with GWT
 
-NOTE
-###
-
-This guide has been mostly superseded by [this libGDX wiki page](https://github.com/libgdx/libgdx/wiki/HTML5-Backend-and-GWT-Specifics).
+**NOTE:** This guide has been mostly superseded by [this libGDX wiki page](https://libgdx.com/wiki/html5-backend-and-gwt-specifics).
 It is here as just another source that might help.
 
 Google Web Toolkit is nice to have because it gives libGDX applications the option to deploy to a web target.

--- a/Guide.md
+++ b/Guide.md
@@ -223,7 +223,7 @@ other projects or older versions.
 - MacOS does not like the legacy desktop apps, showing all sorts of visual glitches.
   It seems to work fine with LWJGL3, in part because that platform had special attention
   paid to it so the `gradlew lwjgl3:run` command can work at all on MacOS.
-    - Consider adding the third-party extension Guacamole to handle a special macOS/LWJGL3 requirement (it
+    - Consider adding the third-party extension Guacamole to handle a special MacOS/LWJGL3 requirement (it
       needs `-XstartOnFirstThread` to be passed to the `java` command, but Guacamole can handle this for you
       and your users).
     - Apps for end-users have to include a bundled JRE to be distributed via the Mac App Store, and it's generally a

--- a/Guide.md
+++ b/Guide.md
@@ -45,7 +45,7 @@ dependencies on vulnerable log4j versions.
 - Get the latest `gdx-liftoff.jar` from the [Releases tab](https://github.com/tommyettinger/gdx-liftoff/releases) of this project.
     - If you have an older gdx-liftoff.jar, or you aren't sure when it was released, getting the current latest is a good idea.
 - Regardless of what platforms you intend to target, make sure the steps
-  [described by the libGDX wiki here](https://github.com/libgdx/libgdx/wiki/Setting-up-your-Development-Environment-%28Eclipse%2C-Intellij-IDEA%2C-NetBeans%29)
+  [described by the libGDX wiki here](https://libgdx.com/wiki/start/setup)
   are taken care of.
 - Run the JAR. Plug in whatever options you see fit:
     - For the Platforms tab, LWJGL3 starts enabled by default (it works on all desktop/laptop platforms), and you can
@@ -64,7 +64,7 @@ dependencies on vulnerable log4j versions.
             - LWJGL2 should mostly be preferred if you need to also depend on gdx-tools, such as if you need to run the
               texture packer at runtime. Some machines have issues with an inconsistent or very high framerate with LWJGL3,
               and using the "Legacy" desktop can fix that. This platform can also be less compatible with some JDKs, and
-              distributing a JDK from [AdoptOpenJDK](https://adoptopenjdk.net/) usually fixes that.
+              distributing a JDK from [Adoptium](https://adoptium.net/) usually fixes that.
                 - The framerate limit problem is currently solved with both LWJGL2 and LWJGL3, as long as you use libGDX
                   1.9.12 or higher.
                 - The "less compatible" JDK issue manifests as a crash immediately at startup, with several warnings printed
@@ -111,7 +111,7 @@ dependencies on vulnerable log4j versions.
           different on HTML due to the tool used, Google Web Toolkit (GWT). It's almost always possible to work around
           these differences and make things like random seeds act the same on all platforms, but it takes work. Mostly,
           you need to be careful with the `long` and `int` number types, and relates to `int` not overflowing as it
-          would on desktop, and `long` not being visible to reflection. See [this small guide to GWT](https://github.com/libgdx/libgdx/wiki/HTML5-Backend-and-GWT-Specifics)
+          would on desktop, and `long` not being visible to reflection. See [this small guide to GWT](https://libgdx.com/wiki/html5-backend-and-gwt-specifics)
           for more. It's very likely that you won't notice any difference unless you try to make behavior identical on GWT
           and other platforms, and even then there may be nothing apparent.
             - GWT 2.9.0 is available but doesn't integrate with libGDX by default; there's a third-party [replacement to the
@@ -162,7 +162,7 @@ dependencies on vulnerable log4j versions.
 
 Now you'll have a project all set up with a sample. In IntelliJ IDEA or Android Studio, you can choose to open the
 `build.gradle` file and select "Open as Project" to get started. In Eclipse or Netbeans, the process should be similar;
-see [libGDX's documentation](https://libgdx.badlogicgames.com/documentation/gettingstarted/Importing%20into%20IDE.html).
+see [libGDX's documentation](https://libgdx.com/wiki/start/import-and-running).
 
 - The way to run a game project that's probably the most reliable is to use Gradle tasks
   to do any part of the build/run process. The simplest way to do this is in the IDE itself,
@@ -223,7 +223,7 @@ other projects or older versions.
 - MacOS does not like the legacy desktop apps, showing all sorts of visual glitches.
   It seems to work fine with LWJGL3, in part because that platform had special attention
   paid to it so the `gradlew lwjgl3:run` command can work at all on MacOS.
-    - Consider adding the third-party extension Guacamole to handle a special MacOS/LWJGL3 requirement (it
+    - Consider adding the third-party extension Guacamole to handle a special macOS/LWJGL3 requirement (it
       needs `-XstartOnFirstThread` to be passed to the `java` command, but Guacamole can handle this for you
       and your users).
     - Apps for end-users have to include a bundled JRE to be distributed via the Mac App Store, and it's generally a

--- a/src/main/kotlin/gdx/liftoff/actions/GlobalActionContainer.kt
+++ b/src/main/kotlin/gdx/liftoff/actions/GlobalActionContainer.kt
@@ -67,8 +67,8 @@ class GlobalActionContainer : ActionContainer {
                 return false
             }
         }
-        if(!input.contains('.') || input.matches(Regex("(^\\.)|(\\.$)"))) {
-            return false;
+        if (!input.contains('.') || input.matches(Regex("(^\\.)|(\\.$)"))) {
+            return false
         }
         return true
     }

--- a/src/main/kotlin/gdx/liftoff/data/libraries/official/officialExtensions.kt
+++ b/src/main/kotlin/gdx/liftoff/data/libraries/official/officialExtensions.kt
@@ -72,7 +72,7 @@ class Ashley : OfficialExtension() {
 @Extension(official = true)
 class Box2D : OfficialExtension() {
     override val id = "gdx-box2d"
-    override val url = "https://github.com/libgdx/libgdx/wiki/Box2d"
+    override val url = "https://libgdx.com/wiki/extensions/physics/box2d"
 
     override fun initiate(project: Project) {
         addDependency(project, Core.ID, "com.badlogicgames.gdx:gdx-box2d:\$gdxVersion")
@@ -123,7 +123,7 @@ class Box2DLights : OfficialExtension() {
 @Extension(official = true)
 class Bullet : OfficialExtension() {
     override val id = "gdx-bullet"
-    override val url = "https://github.com/libgdx/libgdx/wiki/Bullet-physics"
+    override val url = "https://libgdx.com/wiki/extensions/physics/bullet/bullet-physics"
 
     override fun initiate(project: Project) {
         addDependency(project, Core.ID, "com.badlogicgames.gdx:gdx-bullet:\$gdxVersion")
@@ -180,7 +180,7 @@ class Controllers : OfficialExtension() {
 @Extension(official = true)
 class Freetype : OfficialExtension() {
     override val id = "gdx-freetype"
-    override val url = "https://github.com/libgdx/libgdx/wiki/Gdx-freetype"
+    override val url = "https://libgdx.com/wiki/extensions/gdx-freetype"
 
     override fun initiate(project: Project) {
         addDependency(project, Core.ID, "com.badlogicgames.gdx:gdx-freetype:\$gdxVersion")
@@ -204,7 +204,7 @@ class Freetype : OfficialExtension() {
 @Extension(official = true)
 class Tools : OfficialExtension() {
     override val id = "gdx-tools"
-    override val url = "https://github.com/libgdx/libgdx/wiki/Texture-packer"
+    override val url = "https://libgdx.com/wiki/tools/texture-packer"
 
     override fun initiate(project: Project) {
         addDependency(project, Lwjgl2.ID, "com.badlogicgames.gdx:gdx-tools:\$gdxVersion")

--- a/src/main/kotlin/gdx/liftoff/data/templates/unofficial/VisUIBasicTemplate.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/unofficial/VisUIBasicTemplate.kt
@@ -18,7 +18,7 @@ class VisUIBasicTemplate : Template {
     override val id = "visUiBasicTemplate"
     override val description: String
         get() = "Project template included simple launchers and an `ApplicationAdapter` extension with GUI created " +
-            "using the [VisUI](https://github.com/kotcrab/VisEditor/wiki/VisUI) library."
+            "using the [VisUI](https://github.com/kotcrab/vis-ui) library."
 
     override fun apply(project: Project) {
         super.apply(project)

--- a/src/main/kotlin/gdx/liftoff/data/templates/unofficial/VisUIShowcaseTemplate.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/unofficial/VisUIShowcaseTemplate.kt
@@ -23,7 +23,7 @@ class VisUIShowcaseTemplate : Template {
         get() = "600"
     override val description: String
         get() = "Project template included simple launchers and an `ApplicationAdapter` extension with a showcase " +
-            "of widgets created using the [VisUI](https://github.com/kotcrab/VisEditor/wiki/VisUI) library."
+            "of widgets created using the [VisUI](https://github.com/kotcrab/vis-ui) library."
 
     override fun getApplicationListenerContent(project: Project): String = """package ${project.basic.rootPackage};
 

--- a/src/main/kotlin/gdx/liftoff/main.kt
+++ b/src/main/kotlin/gdx/liftoff/main.kt
@@ -144,7 +144,6 @@ fun main() {
             },
             config
         )
-
     }
 }
 

--- a/src/main/resources/templates/tabs/languages.lml
+++ b/src/main/resources/templates/tabs/languages.lml
@@ -13,7 +13,7 @@
     <linkLabel url="https://github.com/oakes/play-clj" expand="true" align="bottom">
         @clojurePrompt
     </linkLabel>
-    <linkLabel url="https://github.com/libgdx/libgdx/wiki/Using-libgdx-with-other-jvm-languages" padBottom="10">
+    <linkLabel url="https://libgdx.com/wiki/jvm-langs/using-libgdx-with-other-jvm-languages" padBottom="10">
         @otherLanguagesPrompt
     </linkLabel>
 </tab>


### PR DESCRIPTION
The libGDX wiki migration broke the old links. This changes some stuff. I'm aware there's many more repositories than just this one that hold links to the libGDX wiki - working on a band-aid for that.

![Spark Barrelson](https://img.huffingtonpost.com/asset/583dff141700002600e7ce3c.jpeg)