### PR TITLE
Add HyperLap2D Runtime and its extensions

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/libraries/unofficial/thirdPartyExtensions.kt
+++ b/src/main/kotlin/gdx/liftoff/data/libraries/unofficial/thirdPartyExtensions.kt
@@ -6,7 +6,9 @@ import gdx.liftoff.data.files.CopiedFile
 import gdx.liftoff.data.files.path
 import gdx.liftoff.data.libraries.Library
 import gdx.liftoff.data.libraries.Repository
+import gdx.liftoff.data.libraries.official.Box2D
 import gdx.liftoff.data.libraries.official.Controllers
+import gdx.liftoff.data.libraries.official.Freetype
 import gdx.liftoff.data.platforms.*
 import gdx.liftoff.data.project.Project
 import gdx.liftoff.views.Extension
@@ -993,6 +995,90 @@ class Lombok : ThirdPartyExtension() {
         addSpecialDependency(project, Core.ID, "annotationProcessor \"org.projectlombok:lombok:\$${id}Version\"")
         // Lombok has special additional code that it needs for GWT.
         // That code is conditionally supplied in the gwt.kt file, in the platforms.
+    }
+}
+
+/**
+ * Add support for HyperLap2D libGDX runtime.
+ * @author fgnm
+ */
+@Extension
+class HyperLap2DRuntime : ThirdPartyExtension() {
+    override val id = "h2d"
+    override val defaultVersion = "0.1.0"
+    override val url = "https://github.com/rednblackgames/hyperlap2d-runtime-libgdx"
+    override val group = "games.rednblack.hyperlap2d"
+    override val name = "runtime-libgdx"
+
+    override fun initiateDependencies(project: Project) {
+        addDependency(project, Core.ID, "games.rednblack.hyperlap2d:runtime-libgdx")
+        addDependency(project, GWT.ID, "games.rednblack.hyperlap2d:runtime-libgdx:sources")
+        addGwtInherit(project, "HyperLap2D")
+
+        Box2D().initiate(project)
+        Freetype().initiate(project)
+        ArtemisOdb().initiate(project)
+    }
+}
+
+/**
+ * Add support for HyperLap2D Spine extension for libGDX runtime.
+ * @author fgnm
+ */
+@Extension
+class HyperLap2DSpineExtension : ThirdPartyExtension() {
+    override val id = "h2dSpineExtension"
+    override val defaultVersion = "0.1.0"
+    override val url = "https://github.com/rednblackgames/h2d-libgdx-spine-extension"
+    override val group = "games.rednblack.hyperlap2d"
+    override val name = "libgdx-spine-extension"
+
+    override fun initiateDependencies(project: Project) {
+        addDependency(project, Core.ID, "games.rednblack.hyperlap2d:libgdx-spine-extension")
+        addDependency(project, GWT.ID, "games.rednblack.hyperlap2d:libgdx-spine-extension:sources")
+        addGwtInherit(project, "HyperLap2D.spine")
+
+        SpineRuntime().initiate(project)
+    }
+}
+
+/**
+ * Add support for HyperLap2D TinyVG extension for libGDX runtime.
+ * @author fgnm
+ */
+@Extension
+class HyperLap2DTinyVGExtension : ThirdPartyExtension() {
+    override val id = "h2dTinyVGExtension"
+    override val defaultVersion = "0.1.0"
+    override val url = "https://github.com/rednblackgames/h2d-libgdx-tinyvg-extension"
+    override val group = "games.rednblack.hyperlap2d"
+    override val name = "libgdx-tinyvg-extension"
+
+    override fun initiateDependencies(project: Project) {
+        addDependency(project, Core.ID, "games.rednblack.hyperlap2d:libgdx-tinyvg-extension")
+        addDependency(project, GWT.ID, "games.rednblack.hyperlap2d:libgdx-tinyvg-extension:sources")
+
+        TinyVG().initiate(project)
+    }
+}
+
+/**
+ * Add support for HyperLap2D Typing Label extension for libGDX runtime.
+ * @author fgnm
+ */
+@Extension
+class HyperLap2DTypingLabelExtension : ThirdPartyExtension() {
+    override val id = "h2dTypingLabelExtension"
+    override val defaultVersion = "0.1.0"
+    override val url = "https://github.com/rednblackgames/h2d-libgdx-typinglabel-extension"
+    override val group = "games.rednblack.hyperlap2d"
+    override val name = "libgdx-typinglabel-extension"
+
+    override fun initiateDependencies(project: Project) {
+        addDependency(project, Core.ID, "games.rednblack.hyperlap2d:libgdx-typinglabel-extension")
+        addDependency(project, GWT.ID, "games.rednblack.hyperlap2d:libgdx-typinglabel-extension:sources")
+
+        TypingLabel().initiate(project)
     }
 }
 

--- a/src/main/resources/i18n/nls.properties
+++ b/src/main/resources/i18n/nls.properties
@@ -102,6 +102,10 @@ screenManager=ScreenManager
 tuningFork=TuningFork
 tinyVG=TinyVG
 gdxPsx=gdx-psx
+h2d=HyperLap2D
+h2dSpineExtension=H2D Spine
+h2dTinyVGExtension=H2D TinyVG
+h2dTypingLabelExtension=H2D Typing Label
 
 issues=https://github.com/tommyettinger/gdx-liftoff/issues
 ok=OK
@@ -343,6 +347,10 @@ screenManagerTip=A screen manager for libGDX supporting transitions.
 tuningForkTip=Advanced audio features for LWJGL3.
 tinyVGTip=Load/render TinyVG vector graphics.
 gdxPsxTip=LibGDX PSX-style render features. Not GWT-compatible.
+h2dTip=Official HyperLap2D Runtime for libGDX.
+h2dSpineExtensionTip=Spine extension for HyperLap2D Runtime.
+h2dTinyVGExtensionTip=TinyVG extension for HyperLap2D Runtime.
+h2dTypingLabelExtensionTip=Typing Label extension for HyperLap2D Runtime.
 
 templates=Templates
 templatesPrompt=Templates generate basic sources of your project to quickly get you started.


### PR DESCRIPTION
Initial support for HyperLap2D world.. It's still missing few things:
- GWT Freetype that's not supported yet
- `robovm.xml` should be modified by adding a `forceLinkClasses` pattern, but I don't know if it's possible in liftoff
- It would be nice to add this bunch of `gdx.reflect.exclude` to the default `GdxDefinition.gwt.xml` if hyperlap is selected, usually people who uses 2D doesn't need 3D and it saves a lot of space in gdx reflection cache. https://github.com/rednblackgames/hyperlap2d-getting-started/blob/c004310a2b2f5cfde08fe089ad8ef2fd92b75e5a/html/src/main/java/games/rednblack/hyperlap2d/example/GdxDefinition.gwt.xml#L19

Cheers!