### PR TITLE
Update gdx-lml libs to the latest release version.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlinVersion=1.6.10
 gdxVersion=1.11.0
-lmlVersion=1.9.1.10.0
+lmlVersion=1.10.1.11.0
 visUiVersion=1.5.0
 commonsExecVersion=1.3
 lwjgl3Version=3.3.1

--- a/src/main/kotlin/gdx/liftoff/data/libraries/unofficial/lml.kt
+++ b/src/main/kotlin/gdx/liftoff/data/libraries/unofficial/lml.kt
@@ -17,16 +17,16 @@ import gdx.liftoff.data.project.Project
 import gdx.liftoff.views.Extension
 
 private const val defaultGroup = "com.crashinvaders.lml"
-private const val fallbackVersion = "1.9.1.10.0"
+private const val fallbackVersion = "1.10.1.11.0"
 
 /**
  * Various utilities for libGDX APIs including GUI building and dependency injection.
  * @author czyzby
- * @author metaphore (CrashInvaders)
+ * @author metaphore (Crashinvaders)
  */
 abstract class LmlExtension : Library {
     /**
-     * Latest version of gdx-lml libraries from the CrashInvaders fork.
+     * Latest version of gdx-lml libraries from the Crashinvaders fork.
      */
     override val defaultVersion = fallbackVersion
     override val repository = LmlRepository


### PR DESCRIPTION
This updates the project's LML dependencies and the template library version to the fresh stable release  - [1.10.1.11.0](https://github.com/crashinvaders/gdx-lml/releases/tag/v1.10.1.11.0)