### PR TITLE
[ios-moe] Disable vertical orientation by default

### DIFF
--- a/src/main/resources/generator/ios-moe/xcode/ios-moe/Info.plist
+++ b/src/main/resources/generator/ios-moe/xcode/ios-moe/Info.plist
@@ -32,15 +32,11 @@
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>


### PR DESCRIPTION
I think it is better to disable vertical orientation by default, since in my experience it is 1. not expected and 2. supporting both orientations reliably requieres a bit more work.