### PR TITLE
TeaVM backend support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ gradle-app.setting
 /headless/build/
 /server/build/
 /shared/build/
+/teavm/build/
 
 ## Java:
 *.class
@@ -53,6 +54,9 @@ com_crashlytics_export_strings.xml
 gwt-unitCache/
 www-test/
 .gwt-tmp/
+
+## TeaVM:
+/teavm/webapp/
 
 ## IntelliJ, Android Studio:
 .idea/

--- a/src/main/kotlin/gdx/liftoff/data/libraries/official/officialExtensions.kt
+++ b/src/main/kotlin/gdx/liftoff/data/libraries/official/officialExtensions.kt
@@ -11,6 +11,7 @@ import gdx.liftoff.data.platforms.GWT
 import gdx.liftoff.data.platforms.Headless
 import gdx.liftoff.data.platforms.Lwjgl2
 import gdx.liftoff.data.platforms.Lwjgl3
+import gdx.liftoff.data.platforms.TeaVM
 import gdx.liftoff.data.platforms.iOS
 import gdx.liftoff.data.project.Project
 import gdx.liftoff.views.Extension
@@ -91,6 +92,8 @@ class Box2D : OfficialExtension() {
         addGwtInherit(project, "com.badlogic.gdx.physics.box2d.box2d-gwt")
 
         addDependency(project, iOS.ID, "com.badlogicgames.gdx:gdx-box2d-platform:\$gdxVersion:natives-ios")
+
+		addDependency(project, TeaVM.ID, "com.github.xpenatan.gdx-web-tools:gdx-box2d-teavm:\$gdxWebToolsVersion")
     }
 }
 
@@ -136,6 +139,8 @@ class Bullet : OfficialExtension() {
         addDesktopDependency(project, "com.badlogicgames.gdx:gdx-bullet-platform:\$gdxVersion:natives-desktop")
 
         addDependency(project, iOS.ID, "com.badlogicgames.gdx:gdx-bullet-platform:\$gdxVersion:natives-ios")
+
+		addDependency(project, TeaVM.ID, "com.github.xpenatan.gdx-web-tools:gdx-bullet-teavm:\$gdxWebToolsVersion")
 
         // Other platforms are not officially supported (GWT).
     }
@@ -193,6 +198,8 @@ class Freetype : OfficialExtension() {
         addDesktopDependency(project, "com.badlogicgames.gdx:gdx-freetype-platform:\$gdxVersion:natives-desktop")
 
         addDependency(project, iOS.ID, "com.badlogicgames.gdx:gdx-freetype-platform:\$gdxVersion:natives-ios")
+
+		addDependency(project, TeaVM.ID, "com.github.xpenatan.gdx-web-tools:gdx-freetype-teavm:\$gdxWebToolsVersion")
 
         // Other platforms are not officially supported (GWT).
     }

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl2.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl2.kt
@@ -13,7 +13,7 @@ import gdx.liftoff.views.GdxPlatform
 class Lwjgl2 : Platform {
     companion object {
         const val ID = "lwjgl2"
-        const val ORDER = Headless.ORDER + 1
+        const val ORDER = TeaVM.ORDER + 1
     }
 
     override val id = ID

--- a/src/main/kotlin/gdx/liftoff/data/platforms/TeaVM.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/TeaVM.kt
@@ -1,0 +1,71 @@
+package gdx.liftoff.data.platforms
+
+import gdx.liftoff.data.files.gradle.GradleFile
+import gdx.liftoff.data.project.Project
+import gdx.liftoff.views.GdxPlatform
+
+/**
+ * Represents the unofficial TeaVM web backend created by xpenatan.
+ */
+@GdxPlatform
+class TeaVM : Platform {
+	companion object {
+		const val ID = "teavm"
+		const val ORDER = Headless.ORDER + 1
+	}
+
+	override val id = ID
+	override val order = ORDER
+	override val isStandard = false
+
+	override fun createGradleFile(project: Project) = TeaVMGradleFile(project)
+
+	override fun initiate(project: Project) {
+		project.properties["gdxWebToolsVersion"] = project.advanced.gdxWebToolsVersion
+		addGradleTaskDescription(project, "run", "starts the application via a local Jetty server.")
+		addGradleTaskDescription(project, "build", "transpiles the application into JavaScript.")
+	}
+}
+
+class TeaVMGradleFile(val project: Project) : GradleFile(TeaVM.ID) {
+	init {
+		dependencies.add("project(':${Core.ID}')")
+
+		addDependency("com.github.xpenatan.gdx-web-tools:backend-web:\$gdxWebToolsVersion")
+		addDependency("com.github.xpenatan.gdx-web-tools:backend-teavm:\$gdxWebToolsVersion")
+		addDependency("com.github.xpenatan.gdx-web-tools:backend-teavm-native:\$gdxWebToolsVersion")
+	}
+
+	override fun getContent() = """plugins {
+  id 'java'
+  id 'org.gretty' version '3.1.0'
+}
+
+gretty {
+  extraResourceBase 'webapp'
+}
+
+sourceSets.main.resources.srcDirs += [ rootProject.file('assets').path ]
+project.ext.mainClassName = '${project.basic.rootPackage}.teavm.TeaVMLauncher'
+eclipse.project.name = appName + '-teavm'
+
+dependencies {
+${joinDependencies(dependencies)}
+}
+
+task buildJavaScript(dependsOn: classes, type: JavaExec) {
+  setDescription("Transpile bytecode to JavaScript via TeaVM")
+  mainClass.set(project.mainClassName)
+  setClasspath(sourceSets.main.runtimeClasspath)
+}
+build.dependsOn buildJavaScript
+
+task run(dependsOn: [buildJavaScript, ":${TeaVM.ID}:jettyRun"]) {
+  setDescription("Run the JavaScript application hosted via a local Jetty server on http://localhost:8080/teavm/")
+}
+
+clean.doLast {
+    file('webapp').deleteDir()
+}
+"""
+}

--- a/src/main/kotlin/gdx/liftoff/data/templates/KotlinTemplate.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/KotlinTemplate.kt
@@ -158,4 +158,32 @@ fun main() {
 	TODO("Implement server application.")
 }
 """
+
+	override fun getTeaVMLauncherContent(project: Project) = """@file:JvmName("TeaVMLauncher")
+
+package ${project.basic.rootPackage}.teavm
+
+import java.io.File
+import com.github.xpenatan.gdx.backends.teavm.TeaBuildConfiguration
+import com.github.xpenatan.gdx.backends.teavm.TeaBuilder
+import com.github.xpenatan.gdx.backends.teavm.plugins.TeaReflectionSupplier
+import ${project.basic.rootPackage}.${project.basic.mainClass}
+
+fun main() {
+	val teaBuildConfiguration = TeaBuildConfiguration()
+	teaBuildConfiguration.assetsPath.add(File("../assets"))
+	teaBuildConfiguration.webappPath = File(".").canonicalPath
+	teaBuildConfiguration.obfuscate = true
+	teaBuildConfiguration.logClasses = false
+	teaBuildConfiguration.setApplicationListener(${project.basic.mainClass}::class.java)
+
+	// Register any extra classpath assets here:
+	// teaBuildConfiguration.additionalAssetsClasspathFiles += "ktx/script/asset.extension";
+
+	// Register any classes or packages that require reflection here:
+	// TeaReflectionSupplier.addReflectionClass("ktx.script.reflected");
+
+	TeaBuilder.build(teaBuildConfiguration)
+}
+"""
 }

--- a/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
@@ -4,12 +4,14 @@ import gdx.liftoff.config.GdxVersion
 import gdx.liftoff.data.files.SourceFile
 import gdx.liftoff.data.files.path
 import gdx.liftoff.data.platforms.Android
+import gdx.liftoff.data.platforms.Assets
 import gdx.liftoff.data.platforms.Core
 import gdx.liftoff.data.platforms.GWT
 import gdx.liftoff.data.platforms.Headless
 import gdx.liftoff.data.platforms.Lwjgl2
 import gdx.liftoff.data.platforms.Lwjgl3
 import gdx.liftoff.data.platforms.Server
+import gdx.liftoff.data.platforms.TeaVM
 import gdx.liftoff.data.platforms.iOS
 import gdx.liftoff.data.platforms.iOSMOE
 import gdx.liftoff.data.project.Project
@@ -51,6 +53,7 @@ interface Template {
         addIOSMOELauncher(project)
         addLwjgl3Launcher(project)
         addServerLauncher(project)
+		addTeaVMLauncher(project)
         project.readmeDescription = description
     }
 
@@ -390,6 +393,45 @@ public class ServerLauncher {
 		// TODO Implement server application.
 	}
 }"""
+
+    fun addTeaVMLauncher(project: Project) {
+        addSourceFile(
+            project = project,
+            platform = TeaVM.ID,
+            packageName = "${project.basic.rootPackage}.teavm",
+            fileName = "TeaVMLauncher.$launcherExtension",
+            content = getTeaVMLauncherContent(project)
+        )
+    }
+    fun getTeaVMLauncherContent(project: Project): String = """package ${project.basic.rootPackage}.teavm;
+
+import com.github.xpenatan.gdx.backends.teavm.TeaBuildConfiguration;
+import com.github.xpenatan.gdx.backends.teavm.TeaBuilder;
+import com.github.xpenatan.gdx.backends.teavm.plugins.TeaReflectionSupplier;
+import java.io.File;
+import java.io.IOException;
+import ${project.basic.rootPackage}.${project.basic.mainClass};
+
+/** Launches the server application. */
+public class TeaVMLauncher {
+	public static void main(String[] args) throws IOException {
+        TeaBuildConfiguration teaBuildConfiguration = new TeaBuildConfiguration();
+        teaBuildConfiguration.assetsPath.add(new File("../${Assets.ID}"));
+        teaBuildConfiguration.webappPath = new File(".").getCanonicalPath();
+        teaBuildConfiguration.obfuscate = true;
+        teaBuildConfiguration.logClasses = false;
+        teaBuildConfiguration.setApplicationListener(${project.basic.mainClass}.class);
+
+		// Register any extra classpath assets here:
+        // teaBuildConfiguration.additionalAssetsClasspathFiles.add("${project.basic.rootPackage.replace('.', '/')}/asset.extension");
+
+        // Register any classes or packages that require reflection here:
+        // TeaReflectionSupplier.addReflectionClass("${project.basic.rootPackage}.reflected");
+
+        TeaBuilder.build(teaBuildConfiguration);
+	}
+}
+"""
 
     fun addSourceFile(
         project: Project,

--- a/src/main/kotlin/gdx/liftoff/views/AdvancedProjectData.kt
+++ b/src/main/kotlin/gdx/liftoff/views/AdvancedProjectData.kt
@@ -63,6 +63,9 @@ class AdvancedProjectData {
     val gwtPluginVersion: String
         get() = gwtPluginVersionField.text
 
+	val gdxWebToolsVersion: String
+		get() = "1.0.0-SNAPSHOT"
+
     val serverJavaVersion: String
         get() = wrangleVersion(serverJavaVersionField.model.text.removeSuffix(".0"))
 

--- a/src/main/resources/i18n/nls.properties
+++ b/src/main/resources/i18n/nls.properties
@@ -8,6 +8,7 @@ html=HTML
 headless=Headless
 shared=Shared
 server=Server
+teavm=HTML (TeaVM)
 
 scala=Scala
 scalaUrl=http://www.scala-lang.org/
@@ -256,12 +257,13 @@ lwjgl2Tip=Legacy desktop backend using LWJGL2.
 lwjgl3Tip=Primary desktop backend using LWJGL3.
 sharedTip=Optional module shared by Core and Server.
 serverTip=Optional server project without libGDX libraries.
+teavmTip=Experimental web backend using TeaVM and WebGL.
 
 languages=Languages
 language=Language
 languageVersion=Version
-languagesPrompt=Note: additional languages do not work with the GWT platform.
-clojurePrompt=See "play-clj" for a Clojure libGDX wrapper, or just use Clojure's Java interop.
+languagesPrompt=Note: unlike TeaVM, the GWT web backend does not support other languages.
+clojurePrompt=See "play-clj" for a Clojure libGDX wrapper, or use Clojure's Java interop.
 otherLanguagesPrompt=Check out this article for more info about other JVM languages.
 
 extensions=Extensions


### PR DESCRIPTION
Adds support for generating projects with a TeaVM-based web module. See #102.

Maintenance considerations:
- Web tools API might change. It's still a snapshot version.
- Gretty plugin might have to be updated to keep up with Gradle API changes.
- Web tools version should be updated or modified to fetch the latest stable release once it is available.