### PR TITLE
TeaVM setup fix

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/platforms/TeaVM.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/TeaVM.kt
@@ -22,8 +22,16 @@ class TeaVM : Platform {
 
 	override fun initiate(project: Project) {
 		project.properties["gdxWebToolsVersion"] = project.advanced.gdxWebToolsVersion
-		addGradleTaskDescription(project, "run", "starts the application via a local Jetty server.")
-		addGradleTaskDescription(project, "build", "transpiles the application into JavaScript.")
+		addGradleTaskDescription(
+			project,
+			"run",
+			"serves the JavaScript application at http://localhost:8080 via a local Jetty server."
+		)
+		addGradleTaskDescription(
+			project,
+			"build",
+			"builds the JavaScript application into the build/dist/webapp folder."
+		)
 	}
 }
 
@@ -38,11 +46,12 @@ class TeaVMGradleFile(val project: Project) : GradleFile(TeaVM.ID) {
 
 	override fun getContent() = """plugins {
   id 'java'
-  id 'org.gretty' version '3.1.0'
+  id 'org.gretty' version '${project.advanced.grettyVersion}'
 }
 
 gretty {
-  extraResourceBase 'webapp'
+  contextPath = '/'
+  extraResourceBase 'build/dist/webapp'
 }
 
 sourceSets.main.resources.srcDirs += [ rootProject.file('assets').path ]
@@ -61,11 +70,7 @@ task buildJavaScript(dependsOn: classes, type: JavaExec) {
 build.dependsOn buildJavaScript
 
 task run(dependsOn: [buildJavaScript, ":${TeaVM.ID}:jettyRun"]) {
-  setDescription("Run the JavaScript application hosted via a local Jetty server on http://localhost:8080/teavm/")
-}
-
-clean.doLast {
-	file('webapp').deleteDir()
+  setDescription("Run the JavaScript application hosted via a local Jetty server at http://localhost:8080/")
 }
 """
 }

--- a/src/main/kotlin/gdx/liftoff/data/templates/KotlinTemplate.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/KotlinTemplate.kt
@@ -171,17 +171,17 @@ import ${project.basic.rootPackage}.${project.basic.mainClass}
 
 fun main() {
 	val teaBuildConfiguration = TeaBuildConfiguration()
-	teaBuildConfiguration.assetsPath.add(File("../assets"))
-	teaBuildConfiguration.webappPath = File(".").canonicalPath
+	teaBuildConfiguration.assetsPath.add(File("..${"$"}{File.separatorChar}assets"))
+	teaBuildConfiguration.webappPath = File("build${"$"}{File.separatorChar}dist").canonicalPath
 	teaBuildConfiguration.obfuscate = true
 	teaBuildConfiguration.logClasses = false
 	teaBuildConfiguration.setApplicationListener(${project.basic.mainClass}::class.java)
 
 	// Register any extra classpath assets here:
-	// teaBuildConfiguration.additionalAssetsClasspathFiles += "ktx/script/asset.extension";
+	// teaBuildConfiguration.additionalAssetsClasspathFiles += "${project.basic.rootPackage.replace('.', '/')}/asset.extension"
 
 	// Register any classes or packages that require reflection here:
-${generateTeaVMReflectionIncludes(project, indent = "    ", trailingSemicolon = false)}
+${generateTeaVMReflectionIncludes(project, indent = "\t", trailingSemicolon = false)}
 
 	TeaBuilder.build(teaBuildConfiguration)
 }

--- a/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
@@ -416,8 +416,8 @@ import ${project.basic.rootPackage}.${project.basic.mainClass};
 public class TeaVMLauncher {
 	public static void main(String[] args) throws IOException {
 		TeaBuildConfiguration teaBuildConfiguration = new TeaBuildConfiguration();
-		teaBuildConfiguration.assetsPath.add(new File("../${Assets.ID}"));
-		teaBuildConfiguration.webappPath = new File(".").getCanonicalPath();
+		teaBuildConfiguration.assetsPath.add(new File(".." + File.separatorChar + "${Assets.ID}"));
+		teaBuildConfiguration.webappPath = new File("build" + File.separatorChar + "dist").getCanonicalPath();
 		teaBuildConfiguration.obfuscate = true;
 		teaBuildConfiguration.logClasses = false;
 		teaBuildConfiguration.setApplicationListener(${project.basic.mainClass}.class);
@@ -434,7 +434,7 @@ ${generateTeaVMReflectionIncludes(project)}
 """
 
 	fun generateTeaVMReflectionIncludes(
-		project: Project, indent: String = "        ", trailingSemicolon: Boolean = true
+		project: Project, indent: String = "\t\t", trailingSemicolon: Boolean = true
 	): String {
 		val semicolon = if (trailingSemicolon) ";" else ""
 		return if (project.reflectedPackages.isEmpty() && project.reflectedClasses.isEmpty()) {

--- a/src/main/kotlin/gdx/liftoff/views/AdvancedProjectData.kt
+++ b/src/main/kotlin/gdx/liftoff/views/AdvancedProjectData.kt
@@ -63,15 +63,24 @@ class AdvancedProjectData {
 	val gwtPluginVersion: String
 		get() = gwtPluginVersionField.text
 
+	/**
+	 * Version of the xpenatan's web tools that include the TeaVM backend.
+	 */
 	val gdxWebToolsVersion: String
 		get() = "1.0.0-SNAPSHOT"
+
+	/**
+	 * Version of the Gretty Gradle plugin used to serve compiled JavaScript applications.
+	 */
+	val grettyVersion: String
+		get() = "3.1.0"
 
 	val serverJavaVersion: String
 		get() = wrangleVersion(serverJavaVersionField.model.text.removeSuffix(".0"))
 
 	val desktopJavaVersion: String
 		get() {
-			var djv = wrangleVersion(desktopJavaVersionField.model.text.removeSuffix(".0"))
+			val djv = wrangleVersion(desktopJavaVersionField.model.text.removeSuffix(".0"))
 			return if(djv.toDouble() < javaVersion.toDouble())
 				javaVersion
 			else


### PR DESCRIPTION
* The application is now compiled to `build/dist/webapp/`.
* Gretty now runs at `localhost:8080/` by default.
* Kotlin template now correctly generates an example classpath resource.
* Gretty version is now stored in advanced project settings for easier maintenance.