### PR TITLE
Project generation warnings; TeaVM update

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/libraries/official/officialExtensions.kt
+++ b/src/main/kotlin/gdx/liftoff/data/libraries/official/officialExtensions.kt
@@ -93,8 +93,8 @@ class Box2D : OfficialExtension() {
 
 		addDependency(project, iOS.ID, "com.badlogicgames.gdx:gdx-box2d-platform:\$gdxVersion:natives-ios")
 
-		// Web tools version of the Box2D is not feature complete; however, TeaVM can compile the GWT Box2D library.
-		// addDependency(project, TeaVM.ID, "com.github.xpenatan.gdx-web-tools:gdx-box2d-teavm:\$gdxWebToolsVersion")
+		// TeaVM version of the Box2D is not feature complete; however, TeaVM can compile the GWT Box2D library.
+		// addDependency(project, TeaVM.ID, "com.github.xpenatan.gdx-teavm:gdx-box2d-teavm:\$gdxWebToolsVersion")
 		addDependency(project, TeaVM.ID, "com.badlogicgames.gdx:gdx-box2d-gwt:\$gdxVersion")
 	}
 }
@@ -142,7 +142,7 @@ class Bullet : OfficialExtension() {
 
 		addDependency(project, iOS.ID, "com.badlogicgames.gdx:gdx-bullet-platform:\$gdxVersion:natives-ios")
 
-		addDependency(project, TeaVM.ID, "com.github.xpenatan.gdx-web-tools:gdx-bullet-teavm:\$gdxWebToolsVersion")
+		addDependency(project, TeaVM.ID, "com.github.xpenatan.gdx-teavm:gdx-bullet-teavm:\$gdxWebToolsVersion")
 
 		// Other platforms are not officially supported (GWT).
 	}
@@ -201,7 +201,7 @@ class Freetype : OfficialExtension() {
 
 		addDependency(project, iOS.ID, "com.badlogicgames.gdx:gdx-freetype-platform:\$gdxVersion:natives-ios")
 
-		addDependency(project, TeaVM.ID, "com.github.xpenatan.gdx-web-tools:gdx-freetype-teavm:\$gdxWebToolsVersion")
+		addDependency(project, TeaVM.ID, "com.github.xpenatan.gdx-teavm:gdx-freetype-teavm:\$gdxWebToolsVersion")
 
 		// Other platforms are not officially supported (GWT).
 	}

--- a/src/main/kotlin/gdx/liftoff/data/platforms/GWT.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/GWT.kt
@@ -317,7 +317,7 @@ sourceSets.main.java.srcDirs = [ "src/main/java/" ]
 
 eclipse.project.name = appName + "-html"
 """ + (
-		if (project.extensions.hasExtensionSelected("lombok")) """
+		if (project.extensions.isSelected("lombok")) """
 
 configurations { lom }
 dependencies {

--- a/src/main/kotlin/gdx/liftoff/data/platforms/TeaVM.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/TeaVM.kt
@@ -21,7 +21,7 @@ class TeaVM : Platform {
 	override fun createGradleFile(project: Project) = TeaVMGradleFile(project)
 
 	override fun initiate(project: Project) {
-		project.properties["gdxWebToolsVersion"] = project.advanced.gdxWebToolsVersion
+		project.properties["gdxTeaVMVersion"] = project.advanced.gdxTeaVMVersion
 		addGradleTaskDescription(
 			project,
 			"run",
@@ -39,9 +39,9 @@ class TeaVMGradleFile(val project: Project) : GradleFile(TeaVM.ID) {
 	init {
 		dependencies.add("project(':${Core.ID}')")
 
-		addDependency("com.github.xpenatan.gdx-web-tools:backend-web:\$gdxWebToolsVersion")
-		addDependency("com.github.xpenatan.gdx-web-tools:backend-teavm:\$gdxWebToolsVersion")
-		addDependency("com.github.xpenatan.gdx-web-tools:backend-teavm-native:\$gdxWebToolsVersion")
+		addDependency("com.github.xpenatan.gdx-teavm:backend-web:\$gdxTeaVMVersion")
+		addDependency("com.github.xpenatan.gdx-teavm:backend-teavm-core:\$gdxTeaVMVersion")
+		addDependency("com.github.xpenatan.gdx-teavm:backend-teavm-native:\$gdxTeaVMVersion")
 	}
 
 	override fun getContent() = """plugins {
@@ -55,7 +55,7 @@ gretty {
 }
 
 sourceSets.main.resources.srcDirs += [ rootProject.file('assets').path ]
-project.ext.mainClassName = '${project.basic.rootPackage}.teavm.TeaVMLauncher'
+project.ext.mainClassName = '${project.basic.rootPackage}.teavm.TeaVMBuilder'
 eclipse.project.name = appName + '-teavm'
 
 dependencies {

--- a/src/main/kotlin/gdx/liftoff/data/project/project.kt
+++ b/src/main/kotlin/gdx/liftoff/data/project/project.kt
@@ -15,7 +15,10 @@ import gdx.liftoff.data.files.path
 import gdx.liftoff.data.languages.Java
 import gdx.liftoff.data.platforms.Android
 import gdx.liftoff.data.platforms.Assets
+import gdx.liftoff.data.platforms.Core
+import gdx.liftoff.data.platforms.GWT
 import gdx.liftoff.data.platforms.Platform
+import gdx.liftoff.data.platforms.TeaVM
 import gdx.liftoff.data.templates.Template
 import gdx.liftoff.views.AdvancedProjectData
 import gdx.liftoff.views.BasicProjectData
@@ -225,10 +228,25 @@ Useful Gradle tasks and flags:
 ${gradleTaskDescriptions.map { "- `${it.key}`: ${it.value}" }.sorted().joinToString(separator = "\n")}
 
 Note that most tasks that are not specific to a single project can be run with `name:` prefix, where the `name` should be replaced with the ID of a specific project.
-For example, `core:clean` removes `build` folder only from the `core` project."""
+For example, `core:clean` removes `build` folder only from the `core` project.
+"""
 				)
 			)
 		}
+	}
+
+	fun getAlertCodes(): List<String> {
+		val alerts = mutableListOf<String>()
+		if (GWT.ID in platforms && languages.getSelectedLanguages().any { it.id != Java().id }) {
+			alerts += "warningNonJavaGwt"
+		}
+		if (TeaVM.ID in platforms) {
+			val coreDependencies = gradleFiles[Core.ID]!!.dependencies
+			if (coreDependencies.any { "kotlinx-coroutines-core" in it }) {
+				alerts += "warningTeaVMCoroutines"
+			}
+		}
+		return alerts
 	}
 
 	fun includeGradleWrapper(logger: ProjectLogger) {

--- a/src/main/kotlin/gdx/liftoff/data/templates/KotlinTemplate.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/KotlinTemplate.kt
@@ -159,7 +159,23 @@ fun main() {
 }
 """
 
-	override fun getTeaVMLauncherContent(project: Project) = """@file:JvmName("TeaVMLauncher")
+	override fun getTeaVMLauncherContent(project: Project): String = """@file:JvmName("TeaVMLauncher")
+
+package ${project.basic.rootPackage}.teavm
+
+import com.github.xpenatan.gdx.backends.teavm.TeaApplicationConfiguration
+import com.github.xpenatan.gdx.backends.web.WebApplication
+import ${project.basic.rootPackage}.${project.basic.mainClass}
+
+fun main() {
+	val config = TeaApplicationConfiguration("canvas")
+	config.width = $width
+	config.height = $height
+	WebApplication(${project.basic.mainClass}(), config)
+}
+"""
+
+	override fun getTeaVMBuilderContent(project: Project) = """@file:JvmName("TeaVMBuilder")
 
 package ${project.basic.rootPackage}.teavm
 
@@ -167,15 +183,13 @@ import java.io.File
 import com.github.xpenatan.gdx.backends.teavm.TeaBuildConfiguration
 import com.github.xpenatan.gdx.backends.teavm.TeaBuilder
 import com.github.xpenatan.gdx.backends.teavm.plugins.TeaReflectionSupplier
-import ${project.basic.rootPackage}.${project.basic.mainClass}
 
 fun main() {
 	val teaBuildConfiguration = TeaBuildConfiguration()
-	teaBuildConfiguration.assetsPath.add(File("..${"$"}{File.separatorChar}assets"))
-	teaBuildConfiguration.webappPath = File("build${"$"}{File.separatorChar}dist").canonicalPath
+	teaBuildConfiguration.assetsPath.add(File("../assets"))
+	teaBuildConfiguration.webappPath = File("build/dist").canonicalPath
+	// You can switch this setting during development:
 	teaBuildConfiguration.obfuscate = true
-	teaBuildConfiguration.logClasses = false
-	teaBuildConfiguration.setApplicationListener(${project.basic.mainClass}::class.java)
 
 	// Register any extra classpath assets here:
 	// teaBuildConfiguration.additionalAssetsClasspathFiles += "${project.basic.rootPackage.replace('.', '/')}/asset.extension"
@@ -183,7 +197,9 @@ fun main() {
 	// Register any classes or packages that require reflection here:
 ${generateTeaVMReflectionIncludes(project, indent = "\t", trailingSemicolon = false)}
 
-	TeaBuilder.build(teaBuildConfiguration)
+	val tool = TeaBuilder.config(teaBuildConfiguration)
+	tool.setMainClass("${project.basic.rootPackage}.teavm.TeaVMLauncher")
+	TeaBuilder.build(tool)
 }
 """
 }

--- a/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
@@ -21,7 +21,7 @@ import gdx.liftoff.data.project.Project
  */
 interface Template {
 	val id: String
-	// Sizes are kept as strings so you can set the sizes to static values, for example: MainClass.WIDTH.
+	// Sizes are kept as strings, so you can set the sizes to static values, for example: MainClass.WIDTH.
 	val width: String
 		get() = "640"
 	val height: String
@@ -318,7 +318,6 @@ import ${project.basic.rootPackage}.${project.basic.mainClass};
 
 /** Launches the iOS (Multi-Os Engine) application. */
 public class IOSLauncher extends IOSApplication.Delegate {
-
 	protected IOSLauncher(Pointer peer) {
 		super(peer);
 	}
@@ -402,25 +401,47 @@ public class ServerLauncher {
 			fileName = "TeaVMLauncher.$launcherExtension",
 			content = getTeaVMLauncherContent(project)
 		)
+		addSourceFile(
+			project = project,
+			platform = TeaVM.ID,
+			packageName = "${project.basic.rootPackage}.teavm",
+			fileName = "TeaVMBuilder.$launcherExtension",
+			content = getTeaVMBuilderContent(project)
+		)
 	}
 	fun getTeaVMLauncherContent(project: Project): String = """package ${project.basic.rootPackage}.teavm;
+
+import com.github.xpenatan.gdx.backends.teavm.TeaApplicationConfiguration;
+import com.github.xpenatan.gdx.backends.web.WebApplication;
+import com.github.xpenatan.gdx.backends.web.WebApplicationConfiguration;
+import ${project.basic.rootPackage}.${project.basic.mainClass};
+
+public class TeaVMLauncher {
+    public static void main(String[] args) {
+        WebApplicationConfiguration config = new TeaApplicationConfiguration("canvas");
+        config.width = $width;
+        config.height = $height;
+        new WebApplication(new ${project.basic.mainClass}(), config);
+    }
+}
+"""
+	fun getTeaVMBuilderContent(project: Project): String = """package ${project.basic.rootPackage}.teavm;
 
 import com.github.xpenatan.gdx.backends.teavm.TeaBuildConfiguration;
 import com.github.xpenatan.gdx.backends.teavm.TeaBuilder;
 import com.github.xpenatan.gdx.backends.teavm.plugins.TeaReflectionSupplier;
 import java.io.File;
 import java.io.IOException;
-import ${project.basic.rootPackage}.${project.basic.mainClass};
+import org.teavm.tooling.TeaVMTool;
 
 /** Launches the server application. */
-public class TeaVMLauncher {
+public class TeaVMBuilder {
 	public static void main(String[] args) throws IOException {
 		TeaBuildConfiguration teaBuildConfiguration = new TeaBuildConfiguration();
-		teaBuildConfiguration.assetsPath.add(new File(".." + File.separatorChar + "${Assets.ID}"));
-		teaBuildConfiguration.webappPath = new File("build" + File.separatorChar + "dist").getCanonicalPath();
+		teaBuildConfiguration.assetsPath.add(new File("../${Assets.ID}"));
+		teaBuildConfiguration.webappPath = new File("build/dist").getCanonicalPath();
+		// You can switch this setting during development:
 		teaBuildConfiguration.obfuscate = true;
-		teaBuildConfiguration.logClasses = false;
-		teaBuildConfiguration.setApplicationListener(${project.basic.mainClass}.class);
 
 		// Register any extra classpath assets here:
 		// teaBuildConfiguration.additionalAssetsClasspathFiles.add("${project.basic.rootPackage.replace('.', '/')}/asset.extension");
@@ -428,7 +449,9 @@ public class TeaVMLauncher {
 		// Register any classes or packages that require reflection here:
 ${generateTeaVMReflectionIncludes(project)}
 
-		TeaBuilder.build(teaBuildConfiguration);
+        TeaVMTool tool = TeaBuilder.config(teaBuildConfiguration);
+        tool.setMainClass(TeaVMLauncher.class.getName());
+        TeaBuilder.build(tool);
 	}
 }
 """

--- a/src/main/kotlin/gdx/liftoff/data/templates/unofficial/KtxTemplate.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/unofficial/KtxTemplate.kt
@@ -4,7 +4,9 @@ import gdx.liftoff.data.files.CopiedFile
 import gdx.liftoff.data.files.path
 import gdx.liftoff.data.libraries.unofficial.KtxApp
 import gdx.liftoff.data.libraries.unofficial.KtxAssets
+import gdx.liftoff.data.libraries.unofficial.KtxAssetsAsync
 import gdx.liftoff.data.libraries.unofficial.KtxAsync
+import gdx.liftoff.data.libraries.unofficial.KtxFreetypeAsync
 import gdx.liftoff.data.libraries.unofficial.KtxGraphics
 import gdx.liftoff.data.platforms.Assets
 import gdx.liftoff.data.project.Project
@@ -38,7 +40,7 @@ class KtxTemplate : KotlinTemplate {
 	}
 
 	private val Project.isUsingAsync: Boolean
-		get() = this.extensions.hasExtensionSelected(KtxAsync().id)
+		get() = listOf(KtxAsync(), KtxAssetsAsync(), KtxFreetypeAsync()).map { it.id }.any(extensions::isSelected)
 
 	override fun getApplicationListenerContent(project: Project): String = """package ${project.basic.rootPackage}
 

--- a/src/main/kotlin/gdx/liftoff/views/AdvancedProjectData.kt
+++ b/src/main/kotlin/gdx/liftoff/views/AdvancedProjectData.kt
@@ -64,9 +64,9 @@ class AdvancedProjectData {
 		get() = gwtPluginVersionField.text
 
 	/**
-	 * Version of the xpenatan's web tools that include the TeaVM backend.
+	 * Version of xpenatan's TeaVM backend.
 	 */
-	val gdxWebToolsVersion: String
+	val gdxTeaVMVersion: String
 		get() = "1.0.0-SNAPSHOT"
 
 	/**

--- a/src/main/kotlin/gdx/liftoff/views/dialogs/GenerationPrompt.kt
+++ b/src/main/kotlin/gdx/liftoff/views/dialogs/GenerationPrompt.kt
@@ -12,6 +12,7 @@ import com.github.czyzby.autumn.mvc.stereotype.ViewDialog
 import com.github.czyzby.lml.annotation.LmlActor
 import gdx.liftoff.config.inject
 import gdx.liftoff.config.threadPool
+import gdx.liftoff.data.project.Project
 import gdx.liftoff.data.project.ProjectLogger
 import gdx.liftoff.views.MainView
 import gdx.liftoff.views.widgets.ScrollableTextArea
@@ -44,6 +45,7 @@ class GenerationPrompt : ViewDialogShower, ProjectLogger {
 				mainView.revalidateForm()
 				project.includeGradleWrapper(this)
 				logNls("generationEnd")
+				logAlerts(project)
 			} catch (exception: Exception) {
 				log(exception.javaClass.name + ": " + exception.message)
 				exception.stackTrace.forEach { log("  at $it") }
@@ -69,5 +71,13 @@ class GenerationPrompt : ViewDialogShower, ProjectLogger {
 				scrollPane.scrollPercentY = 1f
 			}
 		}
+	}
+
+	private fun logAlerts(project: Project) {
+		val alerts = project.getAlertCodes()
+		if (alerts.isEmpty()) return
+
+		logNls("warnings")
+		alerts.forEach(this::logNls)
 	}
 }

--- a/src/main/kotlin/gdx/liftoff/views/extensions.kt
+++ b/src/main/kotlin/gdx/liftoff/views/extensions.kt
@@ -25,7 +25,7 @@ class ExtensionsData : AbstractAnnotationProcessor<Extension>() {
 
 	fun getSelectedOfficialExtensions(): Array<Library> = official.filter { officialButtons.get(it.id).isChecked }.toTypedArray()
 	fun getSelectedThirdPartyExtensions(): Array<Library> = thirdParty.filter { thirdPartyButtons.get(it.id).isChecked }.toTypedArray()
-	fun hasExtensionSelected(id: String): Boolean = (officialButtons.containsKey(id) && officialButtons.get(id).isChecked) || (thirdPartyButtons.containsKey(id) && thirdPartyButtons.get(id).isChecked)
+	fun isSelected(id: String): Boolean = (officialButtons.containsKey(id) && officialButtons.get(id).isChecked) || (thirdPartyButtons.containsKey(id) && thirdPartyButtons.get(id).isChecked)
 
 	// Automatic scanning of extensions:
 	override fun getSupportedAnnotationType(): Class<Extension> = Extension::class.java

--- a/src/main/resources/i18n/nls.properties
+++ b/src/main/resources/i18n/nls.properties
@@ -452,3 +452,7 @@ copyGradle=Copied Gradle wrapper.
 runningGradleTasks=Running Gradle tasks:
 generationEnd=The project is ready. In most modern IDEs you can import it as a Gradle project. Useful Gradle tasks:\n- lwjgl3:run - runs the desktop application, allowing you to test the project template. Change "lwjgl3" to "desktop" if you use the older LWJGL2 platform.\n- lwjgl3:jar - Liftoff uses "jar" to build runnable JAR files that can be distributed; other setup tools often call it "dist" instead, but it does the same thing.\n- gwt:superDev - compiles GWT application and allows you to debug it at localhost:8080/index.html\n\n[GREEN]SETUP COMPLETE[WHITE]
 generationFail=Unable to generate project due to an exception. Try again.\n\n[RED]SETUP FAILED[WHITE]
+
+warnings=\n[YELLOW]WARNINGS[WHITE]
+warningNonJavaGwt=HTML (GWT) platform supports only pure Java applications. Other languages cannot be compiled.
+warningTeaVMCoroutines=HTML (TeaVM) platform does not support Kotlin coroutines. Extensions such as ktx-async might not work.


### PR DESCRIPTION
* Adds warnings printed to the console after project generation.
  * Warns when GWT is chosen along with a non-Java language.
  * Warns when Kotlin coroutines are included when targeting the TeaVM platform.
* Updates TeaVM backend to the new group ID and library names.
* Removes `File.separator` usage as per previous PR comments.
* Separates TeaVM launcher into a builder (compilation setup) and a launcher (TeaVM main with application settings).
* Minor refactoring here and there.