### PR TITLE
TeaVM dependencies update

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/files/gradle/RootGradleFile.kt
+++ b/src/main/kotlin/gdx/liftoff/data/files/gradle/RootGradleFile.kt
@@ -1,6 +1,7 @@
 package gdx.liftoff.data.files.gradle
 
 import gdx.liftoff.data.platforms.Android
+import gdx.liftoff.data.platforms.TeaVM
 import gdx.liftoff.data.project.Project
 
 /**
@@ -56,7 +57,11 @@ subprojects {
 		gradlePluginPortal()
 		maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 		maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
-		maven { url 'https://jitpack.io' }
+		maven { url 'https://jitpack.io' }${
+			if (project.hasPlatform(TeaVM.ID)) {
+				"\n\t\tmaven { url 'https://teavm.org/maven/repository/' }"
+			} else ""
+		}
 	}
 }
 

--- a/src/main/kotlin/gdx/liftoff/data/platforms/TeaVM.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/TeaVM.kt
@@ -40,8 +40,7 @@ class TeaVMGradleFile(val project: Project) : GradleFile(TeaVM.ID) {
 		dependencies.add("project(':${Core.ID}')")
 
 		addDependency("com.github.xpenatan.gdx-teavm:backend-web:\$gdxTeaVMVersion")
-		addDependency("com.github.xpenatan.gdx-teavm:backend-teavm-core:\$gdxTeaVMVersion")
-		addDependency("com.github.xpenatan.gdx-teavm:backend-teavm-native:\$gdxTeaVMVersion")
+		addDependency("com.github.xpenatan.gdx-teavm:backend-teavm:\$gdxTeaVMVersion")
 	}
 
 	override fun getContent() = """plugins {

--- a/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
@@ -416,6 +416,7 @@ import com.github.xpenatan.gdx.backends.web.WebApplication;
 import com.github.xpenatan.gdx.backends.web.WebApplicationConfiguration;
 import ${project.basic.rootPackage}.${project.basic.mainClass};
 
+/** Launches the TeaVM/HTML application. */
 public class TeaVMLauncher {
     public static void main(String[] args) {
         WebApplicationConfiguration config = new TeaApplicationConfiguration("canvas");
@@ -430,11 +431,13 @@ public class TeaVMLauncher {
 import com.github.xpenatan.gdx.backends.teavm.TeaBuildConfiguration;
 import com.github.xpenatan.gdx.backends.teavm.TeaBuilder;
 import com.github.xpenatan.gdx.backends.teavm.plugins.TeaReflectionSupplier;
+import com.github.xpenatan.gdx.backends.web.gen.SkipClass;
 import java.io.File;
 import java.io.IOException;
 import org.teavm.tooling.TeaVMTool;
 
-/** Launches the server application. */
+/** Builds the TeaVM/HTML application. */
+@SkipClass
 public class TeaVMBuilder {
 	public static void main(String[] args) throws IOException {
 		TeaBuildConfiguration teaBuildConfiguration = new TeaBuildConfiguration();

--- a/src/main/kotlin/gdx/liftoff/views/AdvancedProjectData.kt
+++ b/src/main/kotlin/gdx/liftoff/views/AdvancedProjectData.kt
@@ -7,6 +7,7 @@ import com.kotcrab.vis.ui.widget.VisTextField
 import com.kotcrab.vis.ui.widget.spinner.IntSpinnerModel
 import com.kotcrab.vis.ui.widget.spinner.Spinner
 import gdx.liftoff.config.inject
+import gdx.liftoff.data.libraries.Repository.MavenCentral
 
 /**
  * Stores data from "advanced" tab.
@@ -67,7 +68,8 @@ class AdvancedProjectData {
 	 * Version of xpenatan's TeaVM backend.
 	 */
 	val gdxTeaVMVersion: String
-		get() = "1.0.0-SNAPSHOT"
+		get() = MavenCentral.getLatestVersion(group = "com.github.xpenatan.gdx-teavm", name = "backend-teavm")
+			?: "1.0.0-b1"
 
 	/**
 	 * Version of the Gretty Gradle plugin used to serve compiled JavaScript applications.


### PR DESCRIPTION
* Uses the new TeaVM dependencies.
* Updates to the latest TeaVM beta release instead of snapshots. Attempts to fetch the TeaVM backend version from Maven Central.
* Adds `@SkipClass` to the TeaVM builders.
* Refactors the Kotlin TeaVM launcher and builder.