### PR TITLE
README improvements, gdx-liftoff version in demo commit messages

### DIFF
--- a/.github/workflows/publish-demos.yml
+++ b/.github/workflows/publish-demos.yml
@@ -21,6 +21,8 @@ jobs:
         run: chmod +x gradlew
       - name: Generate sample
         run: ./gradlew sample --args="default"
+      - name: Save gdx-liftoff version
+        run: echo "LIFTOFF_VERSION=$(cat version.txt)" >> $GITHUB_ENV
       - name: Publish default sample
         uses: JamesIves/github-pages-deploy-action@v4
         with:
@@ -28,6 +30,7 @@ jobs:
           branch: main
           folder: build/dist/sample
           repository-name: tommyettinger/gdx-liftoff-demo
+          commit-message: 'Automatic deployment: gdx-liftoff ${{ env.LIFTOFF_VERSION }}.'
       - name: Clean basic sample
         run: rm -rf build/dist/sample
       - name: Generate Kotlin sample
@@ -39,3 +42,4 @@ jobs:
           branch: main
           folder: build/dist/sample
           repository-name: tommyettinger/gdx-liftoff-demo-kotlin
+          commit-message: 'Automatic deployment: gdx-liftoff ${{ env.LIFTOFF_VERSION }}.'

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
@@ -16,6 +16,7 @@ class Android : Platform {
 	}
 
 	override val id = ID
+	override val description = "Android mobile platform. Needs Android SDK."
 	override val order = ORDER
 	override val isStandard = false // user should only jump through android hoops on request
 	override fun initiate(project: Project) {

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Assets.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Assets.kt
@@ -4,7 +4,7 @@ import gdx.liftoff.data.files.gradle.GradleFile
 import gdx.liftoff.data.project.Project
 
 /**
- * Mock-up platform. Represents the assets folder.
+ * Mock-up platform. Represents the `assets/` folder.
  */
 class Assets : Platform {
 	companion object {
@@ -13,6 +13,7 @@ class Assets : Platform {
 
 	override val id = ID
 	override val order = -1
+	override val description = ""
 	override val isStandard = false
 
 	override fun createGradleFile(project: Project): GradleFile =

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Core.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Core.kt
@@ -15,6 +15,7 @@ class Core : Platform {
 	}
 
 	override val id = ID
+	override val description = "Main module with the application logic shared by all platforms."
 	override val order = ORDER
 	override val isStandard = false
 	override fun createGradleFile(project: Project): GradleFile {

--- a/src/main/kotlin/gdx/liftoff/data/platforms/GWT.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/GWT.kt
@@ -30,6 +30,7 @@ class GWT : Platform {
 	}
 
 	override val id = ID
+	override val description = "Web platform using GWT and WebGL. Supports only Java projects."
 	override val order = ORDER
 	override val isStandard = false
 

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Headless.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Headless.kt
@@ -16,6 +16,7 @@ class Headless : Platform {
 
 	override val id = ID
 	override val order = ORDER
+	override val description = "Desktop platform without a graphical interface."
 	override val isStandard = false
 
 	override fun createGradleFile(project: Project): GradleFile = HeadlessGradleFile(project)

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl2.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl2.kt
@@ -17,6 +17,7 @@ class Lwjgl2 : Platform {
 	}
 
 	override val id = ID
+	override val description = "Legacy desktop platform using LWJGL2."
 	override val order = ORDER
 	override val isStandard = false // use lwjgl3 instead
 	override fun createGradleFile(project: Project): GradleFile = Lwjgl2GradleFile(project)

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl3.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl3.kt
@@ -17,6 +17,7 @@ class Lwjgl3 : Platform {
 	}
 
 	override val id = ID
+	override val description = "Primary desktop platform using LWJGL3."
 	override val order = ORDER
 
 	// override val isStandard = true // true is the default, and we want to prefer this to desktop

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Platform.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Platform.kt
@@ -15,6 +15,11 @@ interface Platform {
 	val id: String
 
 	/**
+	 * Description of the platform as it appears in the generated project README files.
+	 */
+	val description: String
+
+	/**
 	 * Display order of the platform within the application.
 	 */
 	val order: Int

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Server.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Server.kt
@@ -15,6 +15,7 @@ class Server : Platform {
 	}
 
 	override val id = ID
+	override val description = "A separate application without access to the `core` module."
 	override val order = ORDER
 	override val isStandard = false
 

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Shared.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Shared.kt
@@ -16,6 +16,7 @@ class Shared : Platform {
 
 	override val id = ID
 	override val order = ORDER
+	override val description = "A common module shared by `core` and `server` platforms."
 	override val isStandard = false
 
 	override fun createGradleFile(project: Project): GradleFile = SharedGradleFile(project)

--- a/src/main/kotlin/gdx/liftoff/data/platforms/TeaVM.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/TeaVM.kt
@@ -15,6 +15,7 @@ class TeaVM : Platform {
 	}
 
 	override val id = ID
+	override val description = "Experimental web platform using TeaVM and WebGL."
 	override val order = ORDER
 	override val isStandard = false
 

--- a/src/main/kotlin/gdx/liftoff/data/platforms/iOS.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/iOS.kt
@@ -20,6 +20,7 @@ class iOS : Platform {
 	}
 
 	override val id = ID
+	override val description = "iOS mobile platform using RoboVM."
 	override val order = ORDER
 	override val isStandard = false
 

--- a/src/main/kotlin/gdx/liftoff/data/platforms/iOSMOE.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/iOSMOE.kt
@@ -6,7 +6,6 @@ import com.badlogic.gdx.Files
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import gdx.liftoff.data.files.CopiedFile
-import gdx.liftoff.data.files.ProjectFile
 import gdx.liftoff.data.files.gradle.GradleFile
 import gdx.liftoff.data.files.path
 import gdx.liftoff.data.project.Project
@@ -23,6 +22,7 @@ class iOSMOE : Platform {
 	}
 
 	override val id = ID
+	override val description = "iOS mobile backend using Multi-OS Engine."
 	override val order = ORDER
 	override val isStandard = false
 
@@ -53,7 +53,7 @@ class iOSMOE : Platform {
 		).forEach {
 			project.files.add(
 				CopiedFile(
-					projectName = iOSMOE.ID,
+					projectName = ID,
 					path = path("xcode", "ios-moe", "Media.xcassets", "AppIcon.appiconset", it),
 					original = path("generator", "ios-moe", "xcode", "ios-moe", "Media.xcassets", "AppIcon.appiconset", it)
 				)
@@ -62,7 +62,7 @@ class iOSMOE : Platform {
 
 		project.files.add(
 			CopiedFile(
-				projectName = iOSMOE.ID,
+				projectName = ID,
 				path = path("xcode", "ios-moe", "Media.xcassets", "Contents.json"),
 				original = path("generator", "ios-moe", "xcode", "ios-moe", "Media.xcassets", "Contents.json")
 			)
@@ -82,7 +82,7 @@ class iOSMOE : Platform {
 		).forEach {
 				project.files.add(
 					CopiedFile(
-						projectName = iOSMOE.ID,
+						projectName = ID,
 						path = path("xcode", "ios-moe", it),
 						original = path("generator", "ios-moe", "xcode", "ios-moe", it)
 					)
@@ -91,7 +91,7 @@ class iOSMOE : Platform {
 
 		project.files.add(
 			ReplacedContentFile(
-				projectName = iOSMOE.ID,
+				projectName = ID,
 				path =  path("xcode", "ios-moe", "Info.plist"),
 				original = path("generator", "ios-moe", "xcode", "ios-moe", "Info.plist"),
 				replaceMap = mapOf(Pair("%PACKAGE%", project.basic.rootPackage))
@@ -100,7 +100,7 @@ class iOSMOE : Platform {
 
 		project.files.add(
 			ReplacedContentFile(
-				projectName = iOSMOE.ID,
+				projectName = ID,
 				path = path("xcode", "ios-moe.xcodeproj", "project.pbxproj"),
 				original = path("generator", "ios-moe", "xcode", "ios-moe.xcodeproj", "project.pbxproj"),
 				replaceMap = mapOf(
@@ -114,7 +114,7 @@ class iOSMOE : Platform {
 		arrayOf("Info.plist", "main.cpp").forEach {
 			project.files.add(
 				CopiedFile(
-					projectName = iOSMOE.ID,
+					projectName = ID,
 					path = path("xcode", "ios-moe-Test", it),
 					original = path("generator", "ios-moe", "xcode", "ios-moe-Test", it)
 				)

--- a/src/main/kotlin/gdx/liftoff/data/project/project.kt
+++ b/src/main/kotlin/gdx/liftoff/data/project/project.kt
@@ -221,6 +221,12 @@ A [libGDX](https://libgdx.com/) project generated with [gdx-liftoff](https://git
 
 $readmeDescription
 
+## Platforms
+
+${platforms.values.filter { it.description.isNotBlank() }
+						.sortedBy { it.order }
+						.joinToString(separator = "\n") { "- `${it.id}`: ${it.description}" }}
+
 ## Gradle
 
 This project uses [Gradle](http://gradle.org/) to manage dependencies.

--- a/src/main/kotlin/gdx/liftoff/sample.kt
+++ b/src/main/kotlin/gdx/liftoff/sample.kt
@@ -88,6 +88,7 @@ enum class Preset {
 			}
 		override val template: Template
 			get() = KtxTemplate()
+		override val addSkin: Boolean = false
 	},
 	/** Includes the official platforms supporting Kotlin, as well as TeaVM. Omits unsupported KTX modules. */
 	KTX_WEB {
@@ -113,6 +114,7 @@ enum class Preset {
 			}
 		override val template: Template
 			get() = KtxTemplate()
+		override val addSkin: Boolean = false
 	};
 
 	abstract val projectName: String
@@ -121,6 +123,7 @@ enum class Preset {
 	abstract val languages: List<Language>
 	abstract val thirdPartyExtensions: List<Library>
 	abstract val template: Template
+	open val addSkin: Boolean = true
 
 	val languagesData: LanguagesData
 		get() = LanguagesData(languages.toMutableList(), languages.associate { it.id to it.version })
@@ -163,7 +166,7 @@ fun main(arguments: Array<String>) {
 		gwtPluginVersion = defaults.getDefaultGwtPluginVersion(),
 		serverJavaVersion = defaultJavaVersion,
 		desktopJavaVersion = defaultJavaVersion,
-		generateSkin = true,
+		generateSkin = preset.addSkin,
 		generateReadme = true,
 		gradleTasks = mutableListOf(),
 	)


### PR DESCRIPTION
* `gdx-liftoff` version used to generate project sample is now included in the automated commit message. Since `version.txt` is used to determine the tool version, it will work correctly for stable releases (tags). #94
* Generated project READMEs now include some info on used platforms.
* KTX samples no longer include skin JSON files, as it's encouraged to use type-safe `ktx-style` instead.