### PR TITLE
Added IntelliJ button

### DIFF
--- a/src/main/resources/templates/dialogs/generation.lml
+++ b/src/main/resources/templates/dialogs/generation.lml
@@ -6,5 +6,6 @@
     </scrollPane>
     <:column column="0" toButtonTable="true" padRight="10" padLeft="10" padBottom="10"/>
     <textButton id="close" onResult="close" disabled="true" growX="true" row="true" padTop="10">@closeDialog</textButton>
+    <textButton id="idea" onResult="openIdea" disabled="true" growX="true" row="true">Open in IntelliJ IDEA</textButton>
     <textButton id="exit" onResult="exit" disabled="true" growX="true">@exit</textButton>
 </dialog>


### PR DESCRIPTION
Hey!

I got fed up with IntelliJs slooooow file picker, therefore I added a button to open the project in IntelliJ after generating it.


https://github.com/tommyettinger/gdx-liftoff/assets/11274700/dd848562-1f2f-422d-b1bb-6137e976ec23



Jetbrains Toolbox automatically adds all the installed IDEs to the path, hence it's quite easy to open it! "Generate shell scripts"
![jetbrains-toolbox_Ce4DnmcI2K](https://github.com/tommyettinger/gdx-liftoff/assets/11274700/4b55c143-e9b9-406a-8af7-194152939bdb)

When IntelliJ isn't in the PATH, then the button gets disabled and will show the following error:
![java_BTIh826SVa](https://github.com/tommyettinger/gdx-liftoff/assets/11274700/5ed97061-b7e9-40fc-9f9c-a3cd1778d221)

The way I implemented it should work on Windows, Mac, Linux. 
`where.exe` should be installed on windows by default, and `which` should be installed on macos and linux by default.

I looked into detecting eclipse as well, however eclipse installed itself into a non hardcodable path and doesn't register itself in PATH: 
![image](https://github.com/tommyettinger/gdx-liftoff/assets/11274700/6b97c948-f530-4cf2-b789-05d476b2893b)
