### PR TITLE
Update gdx-basis-universal to v1.0.0

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/libraries/unofficial/ThirdPartyExtensions.kt
+++ b/src/main/kotlin/gdx/liftoff/data/libraries/unofficial/ThirdPartyExtensions.kt
@@ -1023,7 +1023,7 @@ class GdxFlexBox : ThirdPartyExtension() {
 @Extension
 class GdxBasisUniversal : ThirdPartyExtension() {
   override val id = "gdxBasisUniversal"
-  override val defaultVersion = "0.1.0"
+  override val defaultVersion = "1.0.0"
   override val url = "https://github.com/crashinvaders/gdx-basis-universal"
   override val group = "com.crashinvaders.basisu"
   override val name = "basisu-wrapper"


### PR DESCRIPTION
Here's a little update for [gdx-basis-univeral](https://github.com/crashinvaders/gdx-basis-universal) to the latest version.

There's one thing though, I recently found, that most of the modern texture compression formats are not accessible on iOS devices when using the classic `robovm`  backend. Switching on to `robovm-metalangle` solves it. So this is a strong recommendation from the library, to couple it only with the latter. In my experience, it's hard to find downsides in migrating to `robovm-metalangle`. So it would be lovely if there was an option to somehow let users know about the preferred iOS backend when they opt in for this library.