### PR TITLE
Use new svmhelper versioning

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl3.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl3.kt
@@ -53,7 +53,7 @@ class Lwjgl3 : Platform {
       "jar",
       "builds application's runnable jar, which can be found at `$id/build/lib`."
     )
-    project.properties["graalHelperVersion"] = "1.0.0"
+    project.properties["graalHelperVersion"] = "2.0.0"
     project.properties["enableGraalNative"] = "false"
 
     project.files.add(

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl3.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl3.kt
@@ -53,7 +53,7 @@ class Lwjgl3 : Platform {
       "jar",
       "builds application's runnable jar, which can be found at `$id/build/lib`."
     )
-    project.properties["graalHelperVersion"] = "1.12.1"
+    project.properties["graalHelperVersion"] = "1.0.0"
     project.properties["enableGraalNative"] = "false"
 
     project.files.add(
@@ -101,7 +101,7 @@ class Lwjgl3 : Platform {
 
           project(":core") {
             dependencies {
-              implementation "io.github.berstanio:gdx-svmhelper:${'$'}graalHelperVersion"
+              implementation "io.github.berstanio:gdx-svmhelper-annotations:${'$'}graalHelperVersion"
             }
           }
         """.trimIndent()


### PR DESCRIPTION
The old scheme is probably difficult to maintain and confusing, thus why I would like to change it to this, while making sure to ensure backwards compatibility.

It is not released yet, since I wanted to wait for initial feedback.