### PR TITLE
Include more extensions in Graal's resource config file

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl3.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl3.kt
@@ -66,7 +66,7 @@ class Lwjgl3 : Platform {
   "resources":{
   "includes":[
     {
-      "pattern": ".+\\.(png|jpg|jpeg|tmx|tsx|fnt|ttf|otf|json|xml|glsl)"
+      "pattern": ".+\\.(png|jpg|jpeg|tmx|tsx|fnt|ttf|otf|atlas|json|xml|glsl|vert|frag|properties)"
     }
   ]},
   "bundles":[]


### PR DESCRIPTION
This PR adds a few extensions to the list of resources included in Graal native images, namely:
- `.atlas` files, used by some libraries such as VisUI (default skins are included in the jars)
- `.vert` and `.frag`, as not all shaders files have the `glsl` extension (e.g. gdx-vfx)
- `.properties` which is used by I18N bundles, again present in the VisUI library.

Just for the sake of it I printed all extensions present inside my game's .jar, and here's the result:
```
// Already included in the regex
.atlas=2
.fnt=5
.frag=24
.glsl=6
.json=4
.png=10
.properties=19
.vert=6
.xml=21

// Not included in the regex
.class=6850
.dll=21
.dylib=22
.git=30
.ico=1
.LIST=1
.MF=1
.rl=2
.ser=1
.sha1=58
.so=19
.txt=132
```

Perhaps `.ico` would be a good addition as well? Maybe `.txt` as well?