### PR TITLE
update Fleks to 2.6

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/libraries/unofficial/ThirdPartyExtensions.kt
+++ b/src/main/kotlin/gdx/liftoff/data/libraries/unofficial/ThirdPartyExtensions.kt
@@ -187,7 +187,7 @@ class Dialogs : ThirdPartyExtension() {
 @Extension
 class Fleks : ThirdPartyExtension() {
   override val id = "fleks"
-  override val defaultVersion = "2.5"
+  override val defaultVersion = "2.6"
   override val url = "https://github.com/Quillraven/Fleks"
   override val group = "io.github.quillraven.fleks"
   override val name = "Fleks"


### PR DESCRIPTION
2.6 should be live in a few hours and would be cool if it is updated in the next gdx-liftoff version.

Is this the only place that needs to be adjusted?