### PR TITLE
Use relinker in Android

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
@@ -217,7 +217,7 @@ dependencies {
     } else {
       ""
     }}
-${joinDependencies(dependencies)}
+${joinDependencies(dependencies + "\"com.getkeepsafe.relinker:relinker:1.4.4\"")}
 ${joinDependencies(nativeDependencies, "natives")}
 }
 

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
@@ -217,7 +217,7 @@ dependencies {
     } else {
       ""
     }}
-${joinDependencies(dependencies + "\"com.getkeepsafe.relinker:relinker:1.4.4\"")}
+${joinDependencies(dependencies + "\"com.getkeepsafe.relinker:relinker:1.4.5\"")}
 ${joinDependencies(nativeDependencies, "natives")}
 }
 

--- a/src/main/kotlin/gdx/liftoff/data/templates/KotlinTemplate.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/KotlinTemplate.kt
@@ -48,6 +48,8 @@ import android.os.Bundle
 
 import com.badlogic.gdx.backends.android.AndroidApplication
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration
+import com.badlogic.gdx.backends.android.GdxNativeLoader
+import com.getkeepsafe.relinker.ReLinker
 import ${project.basic.rootPackage}.${project.basic.mainClass}
 
 /** Launches the Android application. */
@@ -56,6 +58,7 @@ class AndroidLauncher : AndroidApplication() {
         super.onCreate(savedInstanceState)
         initialize(${project.basic.mainClass}(), AndroidApplicationConfiguration().apply {
             // Configure your application here.
+            nativeLoader = GdxNativeLoader { ReLinker.loadLibrary(this, "gdx") }
             useImmersiveMode = true // Recommended, but not required.
         })
     }

--- a/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
@@ -218,6 +218,7 @@ import android.os.Bundle;
 
 import com.badlogic.gdx.backends.android.AndroidApplication;
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;
+import com.getkeepsafe.relinker.ReLinker;
 import ${project.basic.rootPackage}.${project.basic.mainClass};
 
 /** Launches the Android application. */
@@ -226,6 +227,7 @@ public class AndroidLauncher extends AndroidApplication {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         AndroidApplicationConfiguration configuration = new AndroidApplicationConfiguration();
+        configuration.nativeLoader = () -> ReLinker.loadLibrary(this, "gdx");
         configuration.useImmersiveMode = true; // Recommended, but not required.
         initialize(new ${project.basic.mainClass}(), configuration);
     }


### PR DESCRIPTION
This PR changes the default gdx native loader to [relinker](https://github.com/KeepSafe/ReLinker), to fix some issues in loading native libraries in Android SDK < 23